### PR TITLE
Replace concrete type with param type

### DIFF
--- a/examples/waveguide.jl
+++ b/examples/waveguide.jl
@@ -1,6 +1,6 @@
 using VectorModesolver
 
-function (ε::εtype)(x::Float64, y::Float64) 
+function ε(x::Float64, y::Float64) 
 
     if (0.75 < x < 1.75) && (0.95 < y < 1.55)
         return (4.0, 0.0, 0.0, 4.0, 4.0)
@@ -10,7 +10,6 @@ function (ε::εtype)(x::Float64, y::Float64)
 end
 
 function main()
-    ε = εtype()
     λ = 1.55
     x = [i for i in 0:0.03:2.5]
     y = [i for i in 0:0.05:2.5]

--- a/src/Modesolver.jl
+++ b/src/Modesolver.jl
@@ -1,12 +1,10 @@
-struct εtype <: Function
-end
 
-@with_kw struct VectorialModesolver
+@with_kw struct VectorialModesolver{F}
     λ::Float64
     x::Vector{Float64}
     y::Vector{Float64}
     boundary::Tuple{Int,Int,Int,Int}
-    ε::εtype
+    ε::F
 end
 
 function assemble(ms::VectorialModesolver)


### PR DESCRIPTION
Much easier to just parameterize the `VectorialModesolver` type and still ensure type stability.